### PR TITLE
Specify versions for internal UB19 dependencies

### DIFF
--- a/indexer/pom.xml
+++ b/indexer/pom.xml
@@ -16,6 +16,7 @@
         <dependency>
             <groupId>com.ub19</groupId>
             <artifactId>adapters-lucene</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -23,14 +23,17 @@
         <dependency>
             <groupId>com.ub19</groupId>
             <artifactId>shared-model</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ub19</groupId>
             <artifactId>adapters-lucene</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ub19</groupId>
             <artifactId>adapters-neo4j</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/orchestrator-core/pom.xml
+++ b/orchestrator-core/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>com.ub19</groupId>
             <artifactId>shared-model</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
## Summary
- add `${project.version}` to orchestrator-core's shared-model dependency
- add `${project.version}` to mcp-server's shared-model, adapters-lucene, and adapters-neo4j dependencies
- add `${project.version}` to indexer's adapters-lucene dependency

## Testing
- `mvn -q -Pci -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb054c4860832ead62896edecde945