### PR TITLE
chore: manage Spring Boot Maven plugin centrally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,18 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <profiles>
         <profile>
             <id>ci</id>


### PR DESCRIPTION
## Summary
- manage Spring Boot plugin via parent pluginManagement

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb054d54c8832ea08f28470a325e41