### PR TITLE
Define version properties for common dependencies

### DIFF
--- a/adapters-lucene/pom.xml
+++ b/adapters-lucene/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
+            <version>${jqwik.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-mcp-server</artifactId>
+            <version>${spring-ai.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ub19</groupId>
@@ -40,6 +41,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
+            <version>${maven-invoker.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
         <spring-boot.version>3.3.2</spring-boot.version>
         <lucene.version>9.10.0</lucene.version>
         <neo4j.version>5.19.0</neo4j.version>
+        <spring-ai.version>0.8.1</spring-ai.version>
+        <maven-invoker.version>3.3.0</maven-invoker.version>
+        <jqwik.version>1.8.2</jqwik.version>
     </properties>
 
     <dependencyManagement>

--- a/quality-runner/pom.xml
+++ b/quality-runner/pom.xml
@@ -16,6 +16,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
+            <version>${maven-invoker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Summary
- centralize Spring AI, Maven Invoker, and jqwik versions in parent POM
- reference the new properties in module POMs

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb054edc70832e9ad7a48f66be5ef2